### PR TITLE
adding filter to change number of concurent logins

### DIFF
--- a/prevent-concurrent-logins.php
+++ b/prevent-concurrent-logins.php
@@ -23,7 +23,7 @@ define( 'PREVENT_CONCURRENT_LOGINS_PLUGIN', plugin_basename( __FILE__ ) );
  */
 function pcl_user_has_concurrent_sessions() {
 
-	return ( is_user_logged_in() && count( wp_get_all_sessions() ) > 1 );
+	return ( is_user_logged_in() && count( wp_get_all_sessions() ) > apply_filters( 'pcl_concurrent_logins', 1 ) );
 
 }
 


### PR DESCRIPTION
I have added a filter to allow a dynamic number of concurrent logins. It is posible to change the number of allowed concurrent logins globally or per user/role.

Example:
```php
add_filter('pcl_concurrent_logins', function( $max_logins ){
	return 2;
});
```